### PR TITLE
Adds support for a 'fields' parameter to install_package_to_repo().

### DIFF
--- a/R/descriptions.R
+++ b/R/descriptions.R
@@ -1,6 +1,8 @@
 #' Extract description from source package(s)
 #'
 #' @param x a .tar.gz package
+#' @param fields A vector of DESCRIPTION file fields, or \code{NULL} to extract
+#'   all of them.
 #'
 #' @return a data.table/data.frame object containing Description info
 #' @importFrom data.table rbindlist
@@ -8,7 +10,7 @@
 #'
 #' @examples
 #' extract_description('test.tar.gz')
-extract_description <- function(x) {
+extract_description <- function(x, fields = NULL) {
 
   # unpack description files
   tmp <-
@@ -33,7 +35,7 @@ extract_description <- function(x) {
     data.table::rbindlist(
       lapply(DESCfiles,
              function(file)
-               data.frame(read.dcf(file, fields = NULL))),
+               data.frame(read.dcf(file, fields = fields))),
       fill = TRUE)
   out
 }
@@ -140,13 +142,15 @@ modify_description <- function(field, value, file) {
 #' Extract descriptions from a repository
 #'
 #' @param repo a path to a repository
+#' @param fields A vector of DESCRIPTION file fields, or \code{NULL} to extract
+#'   all of them.
 #'
 #' @return a data.table/data.frame object containing Description info
 #' @export
 #'
 #' @examples
 #' repo_descriptions()
-repo_descriptions <- function(repo = get_repo_location()) {
+repo_descriptions <- function(repo = get_repo_location(), fields = NULL) {
   # Location of source files
   rurl <- contrib.url(repo)
 
@@ -155,7 +159,7 @@ repo_descriptions <- function(repo = get_repo_location()) {
 
   # Extract only description files from tarballs, use the base directory name
   # in the tarball, store them in tempdir
-  out <- extract_description(pacs)
+  out <- extract_description(pacs, fields = fields)
 
   # Add originating location
   out$Path <- pacs

--- a/R/install_package_to_repo.R
+++ b/R/install_package_to_repo.R
@@ -19,6 +19,7 @@
 #' @param repo by default, the value in get_repo_location(), but this can be any repository directory
 #' @param type Which type of package, Currently: 'source' is the only one supported. Plans are to include binaries.
 #' @param repo_name default: NULL, A name to give the repo, will be used by packrat to search for sources in user's options file
+#' @param fields A vector of DESCRIPTION file fields to use in the PACKAGES file.
 #'
 #' @return A Descriptions Table of the packages made available
 #' @import utils
@@ -32,7 +33,8 @@ install_package_to_repo <-
            repos = getOption('repos'),
            repo = get_repo_location(),
            type = 'source',
-           repo_name = get_repo_name()
+           repo_name = get_repo_name(),
+           fields = get_packages_fields()
   ) {
     
     # Fileloc is used for temp files
@@ -191,5 +193,5 @@ install_package_to_repo <-
       print(out)
     }
     
-    write_modpac(repo)
+    write_modpac(repo, fields = fields)
   }

--- a/R/write_modpac.R
+++ b/R/write_modpac.R
@@ -1,11 +1,13 @@
 #' Writes modified PACKAGES files to allow install.packages to access versions
 #'
 #' @param repo Repository Directory (by default, this uses the repo location set with "set_repo_location")
+#' @param fields A vector of DESCRIPTION file fields to use in the PACKAGES file.
 #'
 #' @return A Descriptions Table of the packages made available
 #' @import data.table
 #' @export
-write_modpac <- function(repo = get_repo_location()) {
+write_modpac <- function(repo = get_repo_location(),
+                         fields = get_packages_fields()) {
 
 
   # We write three versions of the PACKAGES file, two in dcf format, 
@@ -22,8 +24,7 @@ write_modpac <- function(repo = get_repo_location()) {
   
   
   # Extract all descriptions, load only confirmed package fields
-  DESCs <- repo_descriptions(repo)
-  cranDESCs <- DESCs[,mget(.cranium[['package_fields']], ifnotfound = NA)]
+  cranDESCs <- repo_descriptions(repo, fields = fields)
 
   cranDESCs <- cranDESCs[,if(.N > 1) rbind(.SD,.SD[is_max_ver(Version)]) else .SD,
                          by = Package]

--- a/man/extract_description.Rd
+++ b/man/extract_description.Rd
@@ -4,10 +4,13 @@
 \alias{extract_description}
 \title{Extract description from source package(s)}
 \usage{
-extract_description(x)
+extract_description(x, fields = NULL)
 }
 \arguments{
 \item{x}{a .tar.gz package}
+
+\item{fields}{A vector of DESCRIPTION file fields, or \code{NULL} to extract
+all of them.}
 }
 \value{
 a data.table/data.frame object containing Description info

--- a/man/install_package_to_repo.Rd
+++ b/man/install_package_to_repo.Rd
@@ -6,7 +6,7 @@
 \usage{
 install_package_to_repo(pkg, repos = getOption("repos"),
   repo = get_repo_location(), type = "source",
-  repo_name = get_repo_name())
+  repo_name = get_repo_name(), fields = get_packages_fields())
 }
 \arguments{
 \item{pkg}{Options:
@@ -32,6 +32,8 @@ a list of repos that will be checked for the package (getOption('repos')) OR an 
 \item{type}{Which type of package, Currently: 'source' is the only one supported. Plans are to include binaries.}
 
 \item{repo_name}{default: NULL, A name to give the repo, will be used by packrat to search for sources in user's options file}
+
+\item{fields}{A vector of DESCRIPTION file fields to use in the PACKAGES file.}
 }
 \value{
 A Descriptions Table of the packages made available

--- a/man/repo_descriptions.Rd
+++ b/man/repo_descriptions.Rd
@@ -4,10 +4,13 @@
 \alias{repo_descriptions}
 \title{Extract descriptions from a repository}
 \usage{
-repo_descriptions(repo = get_repo_location())
+repo_descriptions(repo = get_repo_location(), fields = NULL)
 }
 \arguments{
 \item{repo}{a path to a repository}
+
+\item{fields}{A vector of DESCRIPTION file fields, or \code{NULL} to extract
+all of them.}
 }
 \value{
 a data.table/data.frame object containing Description info

--- a/man/write_modpac.Rd
+++ b/man/write_modpac.Rd
@@ -4,10 +4,12 @@
 \alias{write_modpac}
 \title{Writes modified PACKAGES files to allow install.packages to access versions}
 \usage{
-write_modpac(repo = get_repo_location())
+write_modpac(repo = get_repo_location(), fields = get_packages_fields())
 }
 \arguments{
 \item{repo}{Repository Directory (by default, this uses the repo location set with "set_repo_location")}
+
+\item{fields}{A vector of DESCRIPTION file fields to use in the PACKAGES file.}
 }
 \value{
 A Descriptions Table of the packages made available


### PR DESCRIPTION
This enables calling this function in a stateless manner. It also simplifies the process of reading all of the `DESCRIPTION` files in the repository, since we can know much earlier what fields are wanted.