### PR TITLE
Adds testthat boilerplate and helper functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,12 @@ Imports:
     devtools,
     tools,
     utils
-Suggests: git2r, httr, openssl, getPass
+Suggests:
+    git2r,
+    httr,
+    openssl,
+    getPass,
+    testthat
 License: MIT
 Encoding: UTF-8
 LazyData: true

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(cranium)
+
+test_check("cranium")

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,0 +1,30 @@
+#' Create a Dummy Package Repository
+#'
+#' @param bundles A list of package tarballs to copy into the repository.
+#'
+#' @return The name of the directory containing the repository.
+#'
+#' @noRd
+dummy_repo <- function(bundles, repo = tempfile("repo"), type = "source") {
+  url <- contrib.url(repo, type = type)
+  created <- dir.create(url, recursive = TRUE, showWarnings = FALSE)
+  if (!created) {
+    stop("Failed to create dummy repository directory: '", url, "'.")
+  }
+  copied <- file.copy(bundles, url)
+  if (!all(copied)) {
+    # Clean up in case of failure.
+    unlink(repo, recursive = TRUE)
+    stop("Failed to copy ", sum(copied), " packages to the dummy repository.")
+  }
+  repo
+}
+
+#' Check How Many Packages are Available from the Dummy Repository
+#'
+#' @return The number of packages.
+#'
+#' @noRd
+available <- function(repo, type = "source") {
+  nrow(utils::available.packages(repos = paste0("file://", repo), type = type))
+}

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -28,3 +28,10 @@ dummy_repo <- function(bundles, repo = tempfile("repo"), type = "source") {
 available <- function(repo, type = "source") {
   nrow(utils::available.packages(repos = paste0("file://", repo), type = type))
 }
+
+# Set this to a real list of files to run the tests.
+SAMPLE_BUNDLES <- character(0)
+
+if (length(SAMPLE_BUNDLES) == 0) {
+  stop("Point 'SAMPLE_BUNDLES' towards package tarballs to run the tests.")
+}


### PR DESCRIPTION
In lieu of adding real tests for the moment, this PR adds the `testthat` boilerplate and helper functions that I've been using to set up temporary repositories for testing.