### PR TITLE
Insert a Date/Publication field into DESCRIPTION files

### DIFF
--- a/R/install_package_to_repo.R
+++ b/R/install_package_to_repo.R
@@ -78,7 +78,13 @@ install_package_to_repo <-
           # if repo_name set, rebuild
           if(!is.null(repo_name)) {
             message('Adding repo_name and rebuilding')
-            modify_description('Repository', repo_name, targz)
+            modify_description(
+              field = c("Repository", "Date/Publication"),
+              value = c(
+                repo_name, format.POSIXct(Sys.time(), usetz = TRUE)
+              ),
+              file = targz
+            )
           }
           
           
@@ -120,7 +126,13 @@ install_package_to_repo <-
           # if repo_name set, rebuild
           if(!is.null(repo_name)) {
             message('Adding repo_name and rebuilding')
-            modify_description('Repository', repo_name, targz)
+            modify_description(
+              field = c("Repository", "Date/Publication"),
+              value = c(
+                repo_name, format.POSIXct(Sys.time(), usetz = TRUE)
+              ),
+              file = targz
+            )
           }
           
           unlink(fileloc, recursive = TRUE)
@@ -155,7 +167,13 @@ install_package_to_repo <-
           # if repo_name set, rebuild
           if(!is.null(repo_name)) {
             message('Adding repo_name and rebuilding')
-            modify_description('Repository', repo_name, targz)
+            modify_description(
+              field = c("Repository", "Date/Publication"),
+              value = c(
+                repo_name, format.POSIXct(Sys.time(), usetz = TRUE)
+              ),
+              file = targz
+            )
           }
         }
       }
@@ -167,7 +185,13 @@ install_package_to_repo <-
       
       # Modify Description to use Repo
       if(!is.null(repo_name)) {
-        modify_description('Repository', repo_name, pkg)
+        modify_description(
+          field = c("Repository", "Date/Publication"),
+          value = c(
+            repo_name, format.POSIXct(Sys.time(), usetz = TRUE)
+          ),
+          file = pkg
+        )
       }
       # Copy file from original location to repo
       out <- 
@@ -190,7 +214,13 @@ install_package_to_repo <-
       
       # Modify Description to use Repo
       if(!is.null(repo_name)) {
-        modify_description('Repository', repo_name, out[,2])
+        modify_description(
+          field = c("Repository", "Date/Publication"),
+          value = c(
+            repo_name, format.POSIXct(Sys.time(), usetz = TRUE)
+          ),
+          file = out[,2]
+        )
       }
       
       print(out)

--- a/man/modify_description.Rd
+++ b/man/modify_description.Rd
@@ -2,20 +2,22 @@
 % Please edit documentation in R/descriptions.R
 \name{modify_description}
 \alias{modify_description}
-\title{Modify description of a single zipped package}
+\title{Modify the \code{DESCRIPTION} of a Built Package}
 \usage{
 modify_description(field, value, file)
 }
 \arguments{
-\item{field}{example: Repository}
+\item{field}{A vector of \code{DESCRIPTION} file fields, e.g.
+\code{"Repository"}.}
 
-\item{value}{example: internal}
+\item{value}{A vector of string values these fields should take.}
 
-\item{file}{example: /path/to/cranium_0.3.0.tar.gz}
+\item{file}{A package bundle, e.g. \code{"cranium_1.0.0.tar.gz"}.}
 }
 \value{
-A new available packages table
+\code{TRUE} if the bundle was modified correctly and \code{FALSE} otherwise.
 }
 \description{
-Modify description of a single zipped package
+This function allows you to modify package metadata inside of an existing
+package bundle. Some effort is made to do this as efficiently as possible.
 }


### PR DESCRIPTION
This PR introduces a way to emulate CRAN's addition of a `Date/Publication` field to `DESCRIPTION` files. As a result, we now have publication dates in Cranium repositories. :tada: 

I had to fiddle with `modify_description()` a little to make this work, and made some general improvements while I was in there.

A few related issues I noticed in the process:

* Should we set a default repository name -- like "Cranium" -- instead of having special `NULL` handling?
* The `modify_descriptions()` function could probably be refactored to use `modify_description()`, which would reduce code duplication. Since the former is not used very often, it's possible it would also reduce bugs.
* We could also use `modify_description()` to add a Cranium-specific field, perhaps `CraniumNote: 1.1.0` or the like. Do you think this would be useful?